### PR TITLE
STRUCTURE: Domain Model 구현

### DIFF
--- a/api/src/main/java/com/dalent/api/domain/comment/dao/CommentRepository.java
+++ b/api/src/main/java/com/dalent/api/domain/comment/dao/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.dalent.api.domain.comment.dao;
+
+import com.dalent.api.domain.comment.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/api/src/main/java/com/dalent/api/domain/comment/domain/Comment.java
+++ b/api/src/main/java/com/dalent/api/domain/comment/domain/Comment.java
@@ -1,0 +1,42 @@
+package com.dalent.api.domain.comment.domain;
+
+import com.dalent.api.domain.user.domain.User;
+import com.dalent.api.domain.work.domain.Work;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commentId;
+
+    @ManyToOne
+    @JoinColumn(name = "work_id")
+    private Work work;
+
+    @ManyToOne
+    @JoinColumn(name = "writer")
+    private User writer;
+
+    private String content;
+
+    @OneToOne
+    @JoinColumn(name = "child_comment")
+    private Comment childComment;
+
+    @Builder
+    public Comment(Work work, User writer, String content) {
+        this.work = work;
+        this.writer = writer;
+        this.content = content;
+    }
+
+}

--- a/api/src/main/java/com/dalent/api/domain/follow/dao/FollowRepository.java
+++ b/api/src/main/java/com/dalent/api/domain/follow/dao/FollowRepository.java
@@ -1,0 +1,7 @@
+package com.dalent.api.domain.follow.dao;
+
+import com.dalent.api.domain.follow.domain.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+}

--- a/api/src/main/java/com/dalent/api/domain/follow/domain/Follow.java
+++ b/api/src/main/java/com/dalent/api/domain/follow/domain/Follow.java
@@ -1,0 +1,33 @@
+package com.dalent.api.domain.follow.domain;
+
+import com.dalent.api.domain.user.domain.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Follow {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long followId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "target_id")
+    private User target;
+
+    @Builder
+    Follow(User user, User target) {
+        this.user = user;
+        this.target = target;
+    }
+
+}

--- a/api/src/main/java/com/dalent/api/domain/gallery/dao/GalleryRepository.java
+++ b/api/src/main/java/com/dalent/api/domain/gallery/dao/GalleryRepository.java
@@ -1,0 +1,7 @@
+package com.dalent.api.domain.gallery.dao;
+
+import com.dalent.api.domain.gallery.domain.Gallery;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GalleryRepository extends JpaRepository<Gallery, Long> {
+}

--- a/api/src/main/java/com/dalent/api/domain/gallery/domain/Gallery.java
+++ b/api/src/main/java/com/dalent/api/domain/gallery/domain/Gallery.java
@@ -1,0 +1,31 @@
+package com.dalent.api.domain.gallery.domain;
+
+import com.dalent.api.domain.user.domain.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Gallery {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long galleryId;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String bannerImage;
+
+    @Builder
+    public Gallery(User user, String bannerImage) {
+        this.user = user;
+        this.bannerImage = bannerImage;
+    }
+}

--- a/api/src/main/java/com/dalent/api/domain/user/dao/UserRepository.java
+++ b/api/src/main/java/com/dalent/api/domain/user/dao/UserRepository.java
@@ -1,0 +1,7 @@
+package com.dalent.api.domain.user.dao;
+
+import com.dalent.api.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, String> {
+}

--- a/api/src/main/java/com/dalent/api/domain/user/domain/User.java
+++ b/api/src/main/java/com/dalent/api/domain/user/domain/User.java
@@ -1,0 +1,60 @@
+package com.dalent.api.domain.user.domain;
+
+import com.dalent.api.domain.comment.domain.Comment;
+import com.dalent.api.domain.follow.domain.Follow;
+import com.dalent.api.domain.gallery.domain.Gallery;
+import com.dalent.api.domain.work.domain.Work;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class User {
+
+    @Id
+    private String id;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(length = 20, nullable = false)
+    private String nickname;
+
+    private String profile_image;
+
+    private int heartsCount;
+
+    private String introduce;
+
+    @OneToOne(mappedBy = "gallery")
+    private Gallery gallery;
+
+    @OneToMany(mappedBy = "following")
+    private List<Follow> followings = new ArrayList<>();
+
+    @OneToMany(mappedBy = "followers")
+    private List<Follow> followers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "works")
+    private List<Work> works = new ArrayList<>();
+
+    @OneToMany(mappedBy = "comments")
+    private List<Comment> comments = new ArrayList<>();
+
+    @Builder
+    public User(String id, String password, String nickname) {
+        this.id = id;
+        this.password = password;
+        this.nickname = nickname;
+        this.heartsCount = 0;
+        this.introduce = "";
+    }
+
+}

--- a/api/src/main/java/com/dalent/api/domain/user/domain/User.java
+++ b/api/src/main/java/com/dalent/api/domain/user/domain/User.java
@@ -29,7 +29,13 @@ public class User {
 
     private String profile_image;
 
-    private int heartsCount;
+    private int artStars;
+
+    private int fashionStars;
+
+    private int musicStars;
+
+    private int programmingStars;
 
     private String introduce;
 
@@ -53,7 +59,10 @@ public class User {
         this.id = id;
         this.password = password;
         this.nickname = nickname;
-        this.heartsCount = 0;
+        this.artStars = 0;
+        this.fashionStars = 0;
+        this.musicStars = 0;
+        this.programmingStars = 0;
         this.introduce = "";
     }
 

--- a/api/src/main/java/com/dalent/api/domain/user/domain/User.java
+++ b/api/src/main/java/com/dalent/api/domain/user/domain/User.java
@@ -33,19 +33,19 @@ public class User {
 
     private String introduce;
 
-    @OneToOne(mappedBy = "gallery")
+    @OneToOne(mappedBy = "user")
     private Gallery gallery;
 
-    @OneToMany(mappedBy = "following")
+    @OneToMany(mappedBy = "user")
     private List<Follow> followings = new ArrayList<>();
 
-    @OneToMany(mappedBy = "followers")
+    @OneToMany(mappedBy = "target")
     private List<Follow> followers = new ArrayList<>();
 
-    @OneToMany(mappedBy = "works")
+    @OneToMany(mappedBy = "author")
     private List<Work> works = new ArrayList<>();
 
-    @OneToMany(mappedBy = "comments")
+    @OneToMany(mappedBy = "writer")
     private List<Comment> comments = new ArrayList<>();
 
     @Builder

--- a/api/src/main/java/com/dalent/api/domain/work/dao/WorkRepository.java
+++ b/api/src/main/java/com/dalent/api/domain/work/dao/WorkRepository.java
@@ -1,0 +1,8 @@
+package com.dalent.api.domain.work.dao;
+
+import com.dalent.api.domain.work.domain.Work;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WorkRepository extends JpaRepository<Work, Long> {
+
+}

--- a/api/src/main/java/com/dalent/api/domain/work/domain/Category.java
+++ b/api/src/main/java/com/dalent/api/domain/work/domain/Category.java
@@ -9,7 +9,8 @@ public enum Category {
 
     ART("ART", "미술"),
     MUSIC("MUSIC", "음악"),
-    PROGRAMMING("PROGRAMMING", "프로그래밍");
+    PROGRAMMING("PROGRAMMING", "프로그래밍"),
+    FASHION("FASHION", "패션");
 
     private final String key;
     private final String value;

--- a/api/src/main/java/com/dalent/api/domain/work/domain/Category.java
+++ b/api/src/main/java/com/dalent/api/domain/work/domain/Category.java
@@ -1,0 +1,17 @@
+package com.dalent.api.domain.work.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Category {
+
+    ART("ART", "미술"),
+    MUSIC("MUSIC", "음악"),
+    PROGRAMMING("PROGRAMMING", "프로그래밍");
+
+    private final String key;
+    private final String value;
+
+}

--- a/api/src/main/java/com/dalent/api/domain/work/domain/MediaType.java
+++ b/api/src/main/java/com/dalent/api/domain/work/domain/MediaType.java
@@ -1,0 +1,16 @@
+package com.dalent.api.domain.work.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MediaType {
+
+    IMAGE("image", "이미지"),
+    SOUND("sound", "사운드");
+
+    private final String key;
+    private final String value;
+
+}

--- a/api/src/main/java/com/dalent/api/domain/work/domain/Work.java
+++ b/api/src/main/java/com/dalent/api/domain/work/domain/Work.java
@@ -1,5 +1,6 @@
 package com.dalent.api.domain.work.domain;
 
+import com.dalent.api.domain.comment.domain.Comment;
 import com.dalent.api.domain.user.domain.User;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -42,8 +43,8 @@ public class Work {
     @JoinColumn(name = "author")
     private User author;
 
-    @OneToMany(mappedBy = "comment")
-    private List<Work> works = new ArrayList<>();
+    @OneToMany(mappedBy = "work")
+    private List<Comment> works = new ArrayList<>();
 
     @Builder
     public Work(Category category, String title, String content, MediaType mediaType, String mediaLink,

--- a/api/src/main/java/com/dalent/api/domain/work/domain/Work.java
+++ b/api/src/main/java/com/dalent/api/domain/work/domain/Work.java
@@ -1,0 +1,60 @@
+package com.dalent.api.domain.work.domain;
+
+import com.dalent.api.domain.user.domain.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Work {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long workId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
+    @Column(nullable = false, length = 30)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private int hearts;
+
+    @Enumerated(EnumType.STRING)
+    private MediaType mediaType;
+
+    private String mediaLink;
+
+    private String thumbnailImage;
+
+    @ManyToOne
+    @JoinColumn(name = "author")
+    private User author;
+
+    @OneToMany(mappedBy = "comment")
+    private List<Work> works = new ArrayList<>();
+
+    @Builder
+    public Work(Category category, String title, String content, MediaType mediaType, String mediaLink,
+                String thumbnailImage, User author) {
+        this.category = category;
+        this.title = title;
+        this.content = content;
+        this.mediaType = mediaType;
+        this.mediaLink = mediaLink;
+        this.thumbnailImage = thumbnailImage;
+        this.author = author;
+    }
+
+}

--- a/api/src/main/java/com/dalent/api/domain/work/domain/Work.java
+++ b/api/src/main/java/com/dalent/api/domain/work/domain/Work.java
@@ -30,7 +30,7 @@ public class Work {
     @Column(columnDefinition = "TEXT")
     private String content;
 
-    private int hearts;
+    private int stars;
 
     @Enumerated(EnumType.STRING)
     private MediaType mediaType;


### PR DESCRIPTION
# Base entity 정의
### 요약
* 프로젝트 구조 정의
* 도메인 모델(Entity, Repository) 구현
### 상세
`프로젝트 구조 정의`
DDD 기반으로 프로젝트 구조를 설정했다.
`도메인 모델 구현`
user, follow, work, gallery, comment Entity&Repository 구현
category, mediaType enum class 정의
### 생각해 볼 사안
원래는 User entity의 카테고리 별 star column을 stars VO로 통합하려고 했는데, JPA가 지원하는 메서드 중에서는 VO Column으로 OrderBy가 불가능했다. JPQL같은 조회용 쿼리를 쓰면 될 것 같지만 개발 노력이 더 필요하므로 우선은 VO를 쓰지않고 각 항목을 만들었다.